### PR TITLE
Automatic recovery options

### DIFF
--- a/src/main/kotlin/com/facekom/mq/QueueConnection.kt
+++ b/src/main/kotlin/com/facekom/mq/QueueConnection.kt
@@ -50,6 +50,8 @@ class QueueConnection(private val config: QueueConfig) {
             }
         }
 
+        factory.isAutomaticRecoveryEnabled = config.options.automaticRecoveryEnabled
+
         connection = factory.newConnection()
         connected = true
         logger.info("RabbitMq connection established to ${config.hostname ?: config.url}")

--- a/src/main/kotlin/com/facekom/mq/RabbitMqOptions.kt
+++ b/src/main/kotlin/com/facekom/mq/RabbitMqOptions.kt
@@ -18,6 +18,7 @@ class RabbitMqOptions {
     var password: String? = null
     var vhost: String? = null
     var allowTlsWithoutTrustStore: Boolean = false
+    var automaticRecoveryEnabled: Boolean = true // true is also the default for the rabbitmq client
 
     fun key(value: String): RabbitMqOptions {
         key = value
@@ -48,8 +49,19 @@ class RabbitMqOptions {
         password = value
         return this
     }
+
     fun vhost(value: String): RabbitMqOptions {
         vhost = value
+        return this
+    }
+
+    fun allowTlsWithoutTrustStore(value: Boolean): RabbitMqOptions {
+        allowTlsWithoutTrustStore = value
+        return this
+    }
+
+    fun automaticRecoveryEnabled(value: Boolean): RabbitMqOptions {
+        automaticRecoveryEnabled = value
         return this
     }
 
@@ -61,11 +73,6 @@ class RabbitMqOptions {
             return false
         }
         return true
-    }
-
-    fun allowTlsWithoutTrustStore(value: Boolean): RabbitMqOptions {
-        allowTlsWithoutTrustStore = value
-        return this
     }
 
     fun getSSLContext(): SSLContext {

--- a/src/test/kotlin/TestHelper.kt
+++ b/src/test/kotlin/TestHelper.kt
@@ -56,6 +56,7 @@ class TestHelper {
                         .password("pdfservice")
                         .userName("pdfservice")
                         .allowTlsWithoutTrustStore(true)
+                        .automaticRecoveryEnabled(true)
                 )
         }
 


### PR DESCRIPTION
## Summary

- Added option to set `automaticRecoveryEnabled` of the underlying mq client.
  - Default `true` so it is backwards compatible
  - If you set it to `false` the program will exit on disconnect

### Example usage

```kotlin
            testConfig.hostname("rabbitmq_services")
                .port(5671)
                .protocol(ConnectionProtocol.AMQPS)
                .options(
                    RabbitMqOptions()
                        .vhost("pdfservice")
                        .password("pdfservice")
                        .userName("pdfservice")
                        .allowTlsWithoutTrustStore(true)
                        .automaticRecoveryEnabled(false) // change default behaviour
                )
```

## References
- https://www.rabbitmq.com/api-guide.html (search for `setAutomaticRecoveryEnabled`)