### PR TITLE
Multi URL config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,11 +21,11 @@ repositories {
 
 dependencies {
     implementation("com.rabbitmq:amqp-client:5.16.0")
-    implementation("com.google.code.gson:gson:2.10")
+    implementation("com.google.code.gson:gson:2.10.1")
     implementation(group = "ch.qos.logback", name = "logback-classic", version = "1.4.5")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation("org.jetbrains.kotlin:kotlin-test-junit:1.8.0")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
 }
 
 tasks.test {

--- a/src/main/kotlin/com/facekom/mq/QueueConfig.kt
+++ b/src/main/kotlin/com/facekom/mq/QueueConfig.kt
@@ -87,8 +87,8 @@ class QueueConfig {
                 return url
             }
 
-            val protocol=url.split("://")[0]
-            val ending=url.split("@").last()
+            val protocol = url.split("://")[0]
+            val ending = url.split("@").last()
 
             return "$protocol://$ending"
         }

--- a/src/main/kotlin/com/facekom/mq/QueueConfig.kt
+++ b/src/main/kotlin/com/facekom/mq/QueueConfig.kt
@@ -72,14 +72,19 @@ class QueueConfig {
 
             var credentials = ""
             var port = ""
+            var vhost = ""
+
             if (config.options.userName != null && config.options.password != null) {
                 credentials = "${config.options.userName}:${config.options.password}@"
             }
             if (config.port != null) {
                 port = ":${config.port}"
             }
+            if (config.options.vhost != null) {
+                vhost = "/${config.options.vhost}"
+            }
 
-            return "${config.protocol}://$credentials${config.hostname}$port/${config.options.vhost}"
+            return "${config.protocol}://$credentials${config.hostname}$port$vhost"
         }
 
         fun stripCredentialsFromUrl(url: String): String {

--- a/src/main/kotlin/com/facekom/mq/QueueConfig.kt
+++ b/src/main/kotlin/com/facekom/mq/QueueConfig.kt
@@ -4,7 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class QueueConfig {
-    var url: String? = null
+    var urls = mutableListOf<String>()
     var protocol: String = ConnectionProtocol.AMQP.protocol
     var hostname: String? = null
     var port: Int? = null
@@ -13,8 +13,12 @@ class QueueConfig {
     var rpcTimeoutMs: Int = 10000
     var rpcQueueMaxSize: Int = 100
 
+    fun urls(value: MutableList<String>) {
+        urls = value
+    }
+
     fun url(value: String): QueueConfig {
-        url = value
+        urls = mutableListOf(value)
         return this
     }
 
@@ -57,6 +61,36 @@ class QueueConfig {
         if (hostname == "") return false
         if (!options.isValid()) return false
         return true
+    }
+
+    companion object {
+        fun getUrl(config: QueueConfig): String {
+            if (config.urls.size > 0) {
+                return config.urls[0]
+            }
+
+            var credentials = ""
+            var port = ""
+            if (config.options.userName != null && config.options.password != null) {
+                credentials = "${config.options.userName}:${config.options.password}@"
+            }
+            if (config.port != null) {
+                port = ":${config.port}"
+            }
+
+            return "${config.protocol}://$credentials${config.hostname}$port/${config.options.vhost}"
+        }
+
+        fun stripCredentialsFromUrl(url: String): String {
+            if (!url.contains("@")) {
+                return url
+            }
+
+            val protocol=url.split("://")[0]
+            val ending=url.split("@").last()
+
+            return "$protocol://$ending"
+        }
     }
 }
 

--- a/src/main/kotlin/com/facekom/mq/QueueConfig.kt
+++ b/src/main/kotlin/com/facekom/mq/QueueConfig.kt
@@ -13,8 +13,9 @@ class QueueConfig {
     var rpcTimeoutMs: Int = 10000
     var rpcQueueMaxSize: Int = 100
 
-    fun urls(value: MutableList<String>) {
+    fun urls(value: MutableList<String>): QueueConfig {
         urls = value
+        return this
     }
 
     fun url(value: String): QueueConfig {

--- a/src/main/kotlin/com/facekom/mq/QueueConnection.kt
+++ b/src/main/kotlin/com/facekom/mq/QueueConnection.kt
@@ -24,7 +24,7 @@ class QueueConnection(private val config: QueueConfig) {
             return
         }
 
-        if (config.urls.size == 0) { //backwards compatibility - add url object as url string...
+        if (config.urls.size == 0) { // backwards compatibility - add url object as url string...
             config.url(QueueConfig.getUrl(config))
         }
 

--- a/src/main/kotlin/com/facekom/mq/QueueConnection.kt
+++ b/src/main/kotlin/com/facekom/mq/QueueConnection.kt
@@ -3,7 +3,6 @@ package com.facekom.mq
 import com.rabbitmq.client.Channel
 import com.rabbitmq.client.Connection
 import com.rabbitmq.client.ConnectionFactory
-import com.sun.net.httpserver.Authenticator.Success
 
 class QueueConnection(private val config: QueueConfig) {
     private var factory = ConnectionFactory()

--- a/src/test/kotlin/QueueConfigTest.kt
+++ b/src/test/kotlin/QueueConfigTest.kt
@@ -1,0 +1,13 @@
+import com.facekom.mq.QueueConfig
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.*
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class QueueConfigTest {
+    @Test
+    fun testStripCredentialsFromUrl() {
+        val url = QueueConfig.stripCredentialsFromUrl("amqps://user:pass@localhost:5671/vhost")
+        assertEquals("amqps://localhost:5671/vhost", url)
+    }
+}

--- a/src/test/kotlin/QueueConnectionTest.kt
+++ b/src/test/kotlin/QueueConnectionTest.kt
@@ -31,4 +31,13 @@ class QueueConnectionTest {
             connection.connected
         }
     }
+
+    @Test
+    fun testConnectWithObject() {
+        val connection = QueueConnection(testhelper.testConfigObject)
+
+        connection.connect()
+
+        assertTrue { connection.connected }
+    }
 }

--- a/src/test/kotlin/TestHelper.kt
+++ b/src/test/kotlin/TestHelper.kt
@@ -1,4 +1,3 @@
-import com.facekom.mq.ConnectionProtocol
 import com.facekom.mq.QueueConfig
 import com.facekom.mq.QueueMessage
 import com.facekom.mq.RabbitMqOptions
@@ -45,10 +44,12 @@ class TestHelper {
 
     init {
         if (System.getenv("TEST_ENV") == "travis") {
-            testConfig.urls(mutableListOf(
-                "amqp://invalid:credentials@localhost:5672",
-                "amqp://guest:guest@localhost:5672"
-            ))
+            testConfig.urls(
+                mutableListOf(
+                    "amqp://invalid:credentials@localhost:5672",
+                    "amqp://guest:guest@localhost:5672"
+                )
+            )
         } else {
             testConfig.urls(
                 mutableListOf(

--- a/src/test/kotlin/TestHelper.kt
+++ b/src/test/kotlin/TestHelper.kt
@@ -45,16 +45,20 @@ class TestHelper {
 
     init {
         if (System.getenv("TEST_ENV") == "travis") {
-            testConfig.url("amqp://guest:guest@localhost:5672")
+            testConfig.urls(mutableListOf(
+                "amqp://invalid:credentials@localhost:5672",
+                "amqp://guest:guest@localhost:5672"
+            ))
         } else {
-            testConfig.hostname("rabbitmq-services")
-                .port(5671)
-                .protocol(ConnectionProtocol.AMQPS)
+            testConfig.urls(
+                mutableListOf(
+                    "amqps://invalid:credentials@rabbitmq-cluster-1:5671/pdfservice",
+                    "amqps://pdfservice:pdfservice@rabbitmq-cluster-2:5671/pdfservice",
+                    "amqps://pdfservice:pdfservice@rabbitmq-cluster-3:5671/pdfservice"
+                )
+            )
                 .options(
                     RabbitMqOptions()
-                        .vhost("pdfservice")
-                        .password("pdfservice")
-                        .userName("pdfservice")
                         .allowTlsWithoutTrustStore(true)
                         .automaticRecoveryEnabled(true)
                 )

--- a/src/test/kotlin/TestHelper.kt
+++ b/src/test/kotlin/TestHelper.kt
@@ -88,7 +88,6 @@ class TestHelper {
                         .password("pdfservice")
                         .vhost("pdfservice")
                 )
-
         }
 
         val base64Decoder = Base64.getDecoder()

--- a/src/test/kotlin/TestHelper.kt
+++ b/src/test/kotlin/TestHelper.kt
@@ -1,3 +1,4 @@
+import com.facekom.mq.ConnectionProtocol
 import com.facekom.mq.QueueConfig
 import com.facekom.mq.QueueMessage
 import com.facekom.mq.RabbitMqOptions
@@ -10,6 +11,7 @@ class TestHelper {
     val logger: Logger = LoggerFactory.getLogger("brandNewTestLogger")
 
     var testConfig = QueueConfig()
+    var testConfigObject = QueueConfig()
 
     val messageOK = { data: JsonElement -> QueueMessage("ok", data) }
     val messageErr = { data: JsonElement -> QueueMessage("error", data) }
@@ -50,6 +52,16 @@ class TestHelper {
                     "amqp://guest:guest@localhost:5672"
                 )
             )
+
+            testConfigObject
+                .protocol(ConnectionProtocol.AMQP)
+                .hostname("localhost")
+                .port(5672)
+                .options(
+                    RabbitMqOptions()
+                        .userName("guest")
+                        .password("guest")
+                )
         } else {
             testConfig.urls(
                 mutableListOf(
@@ -63,6 +75,20 @@ class TestHelper {
                         .allowTlsWithoutTrustStore(true)
                         .automaticRecoveryEnabled(true)
                 )
+
+            testConfigObject
+                .protocol(ConnectionProtocol.AMQPS)
+                .hostname("rabbitmq-cluster-1")
+                .port(5671)
+                .options(
+                    RabbitMqOptions()
+                        .allowTlsWithoutTrustStore(true)
+                        .automaticRecoveryEnabled(true)
+                        .userName("pdfservice")
+                        .password("pdfservice")
+                        .vhost("pdfservice")
+                )
+
         }
 
         val base64Decoder = Base64.getDecoder()


### PR DESCRIPTION
## Summary

- Added option to configure multiple URLs
  - Backwards compatible with older `QueueConfig` methods, but they only support the single URL usage
  - First successful connection will be used
- Remove credentials from urls before logging them
- Dependency updates