### PR TITLE
Queue assertion options

### DIFF
--- a/src/main/kotlin/com/facekom/mq/Options.kt
+++ b/src/main/kotlin/com/facekom/mq/Options.kt
@@ -61,7 +61,7 @@ open class AssertExchangeOptions {
     var assert: Boolean = true
     var durable: Boolean = true
     var autoDelete: Boolean = false
-    var arguments: Map<String, Any> = mutableMapOf()
+    open var arguments: Map<String, Any> = mutableMapOf()
 }
 
 open class AssertQueueOptions {
@@ -69,6 +69,7 @@ open class AssertQueueOptions {
     var durable: Boolean = true
     var exclusive: Boolean = false
     var autoDelete: Boolean = false
+    open var arguments: Map<String, Any> = mutableMapOf()
 }
 
 open class RpcClientOptions {
@@ -86,7 +87,7 @@ open class RpcClientOptions {
 open class RpcServerOptions {
     var timeOutMs: Int = 10000
     var prefetchCount: Int = 1
-    val queue: AssertQueueOptions = AssertQueueOptions()
+    var queue: AssertQueueOptions = AssertQueueOptions()
 }
 
 open class PublisherOptions {
@@ -96,7 +97,7 @@ open class PublisherOptions {
 open class SubscriberOptions {
     val connection: ConnectionOptions = ConnectionOptions()
     val exchange: AssertExchangeOptions = AssertExchangeOptions()
-    val queue: AssertQueueOptions = AssertQueueOptions()
+    var queue: AssertQueueOptions = AssertQueueOptions()
 
     init {
         queue.exclusive = true
@@ -104,10 +105,10 @@ open class SubscriberOptions {
 }
 
 open class QueueClientOptions {
-    val queue: AssertQueueOptions = AssertQueueOptions()
+    var queue: AssertQueueOptions = AssertQueueOptions()
 }
 
 open class QueueServerOptions {
     var connection: ConnectionOptions = ConnectionOptions()
-    val queue: AssertQueueOptions = AssertQueueOptions()
+    var queue: AssertQueueOptions = AssertQueueOptions()
 }

--- a/src/main/kotlin/com/facekom/mq/QueueClient.kt
+++ b/src/main/kotlin/com/facekom/mq/QueueClient.kt
@@ -18,12 +18,13 @@ open class QueueClient(
         val durableQueue = options.queue.durable
         val exclusiveQueue = options.queue.exclusive
         val autoDeleteQueue = options.queue.autoDelete
+        val arguments = options.queue.arguments
 
         try {
             val channel = queueConnection.getChannel()
 
             if (options.queue.assert) {
-                channel.queueDeclare(queueName, durableQueue, exclusiveQueue, options.queue.autoDelete, null)
+                channel.queueDeclare(queueName, durableQueue, exclusiveQueue, autoDeleteQueue, arguments)
                 logger.info("QueueClient initialized queue($queueName) durable($durableQueue) exclusive($exclusiveQueue) autoDelete($autoDeleteQueue)")
             } else {
                 logger.info("QueueClient initialize queue($queueName) skipped assertion")

--- a/src/main/kotlin/com/facekom/mq/QueueServer.kt
+++ b/src/main/kotlin/com/facekom/mq/QueueServer.kt
@@ -18,13 +18,14 @@ open class QueueServer(
         val durableQueue = options.queue.durable
         val exclusiveQueue = options.queue.exclusive
         val autoDeleteQueue = options.queue.autoDelete
+        val arguments = options.queue.arguments
 
         try {
             val channel = queueConnection.getChannel()
             val prefetchCount = options.connection.prefetchCount
 
             if (options.queue.assert) {
-                channel.queueDeclare(exchangeName, durableQueue, exclusiveQueue, autoDeleteQueue, null)
+                channel.queueDeclare(exchangeName, durableQueue, exclusiveQueue, autoDeleteQueue, arguments)
                 logger.info("QueueServer initialized queue($exchangeName) durable($durableQueue) exclusive($exclusiveQueue) autoDelete($autoDeleteQueue)")
             } else {
                 logger.info("QueueServer initialize queue($exchangeName) skipped assertion")

--- a/src/main/kotlin/com/facekom/mq/RPCClient.kt
+++ b/src/main/kotlin/com/facekom/mq/RPCClient.kt
@@ -51,13 +51,14 @@ open class RPCClient constructor(
             val durableReplyQueue = options.replyQueue.durable
             val exclusiveReplyQueue = options.replyQueue.exclusive
             val autoDeleteReplyQueue = options.replyQueue.autoDelete
+            val arguments = options.replyQueue.arguments
 
             replyQueueName = channel.queueDeclare(
                 replyQueueName,
                 durableReplyQueue,
                 exclusiveReplyQueue,
                 autoDeleteReplyQueue,
-                null
+                arguments
             ).queue
             logger.info("RPCClient initialized reply queue($replyQueueName) durable($durableReplyQueue) exclusive($exclusiveReplyQueue) autoDelete($autoDeleteReplyQueue)")
         } else {

--- a/src/main/kotlin/com/facekom/mq/RPCServer.kt
+++ b/src/main/kotlin/com/facekom/mq/RPCServer.kt
@@ -93,12 +93,13 @@ open class RPCServer(
         val durableQueue = options.queue.durable
         val exclusiveQueue = options.queue.exclusive
         val autoDeleteQueue = options.queue.autoDelete
+        val arguments = options.queue.arguments
 
         try {
             val channel = connection.getChannel()
 
             if (options.queue.assert) {
-                channel.queueDeclare(name, durableQueue, exclusiveQueue, autoDeleteQueue, null)
+                channel.queueDeclare(name, durableQueue, exclusiveQueue, autoDeleteQueue, arguments)
                 logger.info("RPCServer initialized queue($name) durable($durableQueue) exclusive($exclusiveQueue) autoDelete($autoDeleteQueue)")
             } else {
                 logger.info("RPCServer initialize queue($name) skipped assertion")

--- a/src/main/kotlin/com/facekom/mq/Subscriber.kt
+++ b/src/main/kotlin/com/facekom/mq/Subscriber.kt
@@ -29,12 +29,17 @@ open class Subscriber(
                 logger.info("Subscriber initialize exchange($exchangeName) skipped assertion")
             }
 
+            val durableQueue = options.queue.durable
+            val exclusiveQueue = options.queue.exclusive
+            val autoDeleteQueue = options.queue.autoDelete
+            val arguments = options.queue.arguments
+
             val queueName = channel.queueDeclare(
                 "",
-                options.queue.durable,
-                options.queue.exclusive,
-                options.queue.autoDelete,
-                null
+                durableQueue,
+                exclusiveQueue,
+                autoDeleteQueue,
+                arguments,
             ).queue
             channel.queueBind(queueName, exchangeName, "")
             channel.basicConsume(queueName, false, ::onConsumeMessage) { _: String? -> } // consumerTag parameter


### PR DESCRIPTION
## Summary
- Added option to change queue assertion arguments

This can be used to create quorum queues and set arguments like `delivery-limit`.

### Quorum Queue Example:
```kotlin
class AssertQuorumQueueOptions : AssertQueueOptions() {
    override var arguments: Map<String, Any> = mutableMapOf(
        "x-queue-type" to "quorum",
        "delivery-limit" to 30
    )
}

val rpcServerOptions = RpcServerOptions()
rpcServerOptions.queue = AssertQuorumQueueOptions()

rpcServer = queueManager.getRPCServer('myRpcServer', rpcServerOptions)
```
